### PR TITLE
Fix memory leak

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ def nlpstack(component: String) = ("org.allenai.nlpstack" %% s"nlpstack-$compone
   .exclude("edu.stanford.nlp", "stanford-corenlp")
   .exclude("org.slf4j", "log4j-over-slf4j")
 
-def textualEntailment(component: String) = ("org.allenai.textual-entailment" %% component % "1.0.6-SNAPSHOT")
+def textualEntailment(component: String) = ("org.allenai.textual-entailment" %% component % "1.0.6")
   .exclude("org.slf4j", "log4j-over-slf4j")
   .exclude("edu.stanford.nlp", "stanford-corenlp")
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ lazy val commonSettings = Seq(
   organization := ccgGroupId,
   version := "1.5",
   scalaVersion := "2.11.8",
-  javaOptions ++= Seq("-Xmx6G"),
+  javaOptions ++= Seq("-Xmx10G"),
   fork := false,
   // Make sure SCIP libraries are locatable.
   javaOptions += s"-Djava.library.path=lib",

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ lazy val commonSettings = Seq(
   organization := ccgGroupId,
   version := "1.5",
   scalaVersion := "2.11.8",
-  javaOptions ++= Seq("-Xmx25G", "-XX:MaxMetaspaceSize=5g"),
+  javaOptions ++= Seq("-Xmx6G"),
   fork := false,
   // Make sure SCIP libraries are locatable.
   javaOptions += s"-Djava.library.path=lib",

--- a/runViz.sh
+++ b/runViz.sh
@@ -1,3 +1,3 @@
-export SBT_OPTS="-Xmx6G"
+export SBT_OPTS="-Xmx10G"
 export LD_LIBRARY_PATH=:${PWD}/lib
-sbt -Djava.library.path=lib -J-Xmx6G "project viz" "run"
+sbt -Djava.library.path=lib -J-Xmx10G "project viz" "run"

--- a/runViz.sh
+++ b/runViz.sh
@@ -1,1 +1,3 @@
-sbt "project viz" "run"
+export SBT_OPTS="-Xmx6G"
+export LD_LIBRARY_PATH=:${PWD}/lib
+sbt -Djava.library.path=lib -J-Xmx6G "project viz" "run"

--- a/src/main/scala/org/allenai/ari/solvers/textilp/solvers/TextILPSolver.scala
+++ b/src/main/scala/org/allenai/ari/solvers/textilp/solvers/TextILPSolver.scala
@@ -326,55 +326,81 @@ class TextILPSolver(annotationUtils: AnnotationUtils,
     lazy val resultCause = CauseResultRules(q, p) -> "resultCause"
     lazy val resultVerbSRLPlusCommaSRL_pipelneSRL = {
       val ilpSolver = new ScipSolver("textILP", ScipParams.Default)
-      solveTopAnswer(q, p, ilpSolver, aligner, Set(VerbSRLandCommaSRL), useSummary = true, ViewNames.SRL_VERB)
+      val result = solveTopAnswer(q, p, ilpSolver, aligner, Set(VerbSRLandCommaSRL), useSummary = true, ViewNames.SRL_VERB)
+      ilpSolver.free()
+      result
     } -> "resultVerbSRLPlusCommaSRL_pipeline_srl"
     lazy val resultVerbSRLPlusCommaSRL_curatorSRL = {
       val ilpSolver = new ScipSolver("textILP", ScipParams.Default)
-      solveTopAnswer(q, p, ilpSolver, aligner, Set(VerbSRLandCommaSRL), useSummary = true, TextILPSolver.curatorSRLViewName)
+      val result = solveTopAnswer(q, p, ilpSolver, aligner, Set(VerbSRLandCommaSRL), useSummary = true, TextILPSolver.curatorSRLViewName)
+      ilpSolver.free()
+      result
     } -> "resultVerbSRLPlusCommaSRL_curator_srl"
     lazy val resultVerbSRLPlusCommaSRL_pathLSTM = {
       val ilpSolver = new ScipSolver("textILP", ScipParams.Default)
-      solveTopAnswer(q, p, ilpSolver, aligner, Set(VerbSRLandCommaSRL), useSummary = true, TextILPSolver.pathLSTMViewName)
+      val result = solveTopAnswer(q, p, ilpSolver, aligner, Set(VerbSRLandCommaSRL), useSummary = true, TextILPSolver.pathLSTMViewName)
+      ilpSolver.free()
+      result
     } -> "resultVerbSRLPlusCommaSRL"
     lazy val resultSimpleMatching = {
       val ilpSolver = new ScipSolver("textILP", ScipParams.Default)
-      solveTopAnswer(q, p, ilpSolver, aligner, Set(SimpleMatching), useSummary = true, TextILPSolver.pathLSTMViewName)
+      val result = solveTopAnswer(q, p, ilpSolver, aligner, Set(SimpleMatching), useSummary = true, TextILPSolver.pathLSTMViewName)
+      ilpSolver.free()
+      result
     } -> "resultILP"
     lazy val resultVerbSRLPlusCoref_pipelineSRL = {
       val ilpSolver = new ScipSolver("textILP", ScipParams.Default)
-      solveTopAnswer(q, p, ilpSolver, aligner, Set(VerbSRLandCoref), useSummary = true, ViewNames.SRL_VERB)
+      val result = solveTopAnswer(q, p, ilpSolver, aligner, Set(VerbSRLandCoref), useSummary = true, ViewNames.SRL_VERB)
+      ilpSolver.free()
+      result
     } -> "resultVerbSRLPlusCoref_pipeline_srl"
     lazy val resultVerbSRLPlusCoref_curatorSRL = {
       val ilpSolver = new ScipSolver("textILP", ScipParams.Default)
-      solveTopAnswer(q, p, ilpSolver, aligner, Set(VerbSRLandCoref), useSummary = true, TextILPSolver.curatorSRLViewName)
+      val result = solveTopAnswer(q, p, ilpSolver, aligner, Set(VerbSRLandCoref), useSummary = true, TextILPSolver.curatorSRLViewName)
+      ilpSolver.free()
+      result
     } -> "resultVerbSRLPlusCoref_curator_srl"
     lazy val resultVerbSRLPlusCoref_pathLSTM = {
       val ilpSolver = new ScipSolver("textILP", ScipParams.Default)
-      solveTopAnswer(q, p, ilpSolver, aligner, Set(VerbSRLandCoref), useSummary = true, TextILPSolver.pathLSTMViewName)
+      val result = solveTopAnswer(q, p, ilpSolver, aligner, Set(VerbSRLandCoref), useSummary = true, TextILPSolver.pathLSTMViewName)
+      ilpSolver.free()
+      result
     } -> "resultVerbSRLPlusCoref_path_lstm"
     lazy val resultVerbSRLPlusPrepSRL_pipeline_srl = {
       val ilpSolver = new ScipSolver("textILP", ScipParams.Default)
-      solveTopAnswer(q, p, ilpSolver, aligner, Set(VerbSRLandPrepSRL), useSummary = true, ViewNames.SRL_VERB)
+      val result = solveTopAnswer(q, p, ilpSolver, aligner, Set(VerbSRLandPrepSRL), useSummary = true, ViewNames.SRL_VERB)
+      ilpSolver.free()
+      result
     } -> "resultVerbSRLPlusPrepSRL_pipeline_srl"
     lazy val resultVerbSRLPlusPrepSRL_curator_srl = {
       val ilpSolver = new ScipSolver("textILP", ScipParams.Default)
-      solveTopAnswer(q, p, ilpSolver, aligner, Set(VerbSRLandPrepSRL), useSummary = true, TextILPSolver.curatorSRLViewName)
+      val result = solveTopAnswer(q, p, ilpSolver, aligner, Set(VerbSRLandPrepSRL), useSummary = true, TextILPSolver.curatorSRLViewName)
+      ilpSolver.free()
+      result
     } -> "resultVerbSRLPlusPrepSRL_curator_srl"
     lazy val resultVerbSRLPlusPrepSRL_path_lstm = {
       val ilpSolver = new ScipSolver("textILP", ScipParams.Default)
-      solveTopAnswer(q, p, ilpSolver, aligner, Set(VerbSRLandPrepSRL), useSummary = true, TextILPSolver.pathLSTMViewName)
+      val result = solveTopAnswer(q, p, ilpSolver, aligner, Set(VerbSRLandPrepSRL), useSummary = true, TextILPSolver.pathLSTMViewName)
+      ilpSolver.free()
+      result
     } -> "resultVerbSRLPlusPrepSRL_path_lstm"
     lazy val srlV1ILP_pipeline_srl = {
       val ilpSolver = new ScipSolver("textILP", ScipParams.Default)
-      solveTopAnswer(q, p, ilpSolver, aligner, Set(SRLV1ILP), useSummary = false, ViewNames.SRL_VERB)
+      val result = solveTopAnswer(q, p, ilpSolver, aligner, Set(SRLV1ILP), useSummary = false, ViewNames.SRL_VERB)
+      ilpSolver.free()
+      result
     } -> "srlV1ILP_pipeline_srl"
     lazy val srlV1ILP_curator_srl = {
       val ilpSolver = new ScipSolver("textILP", ScipParams.Default)
-      solveTopAnswer(q, p, ilpSolver, aligner, Set(SRLV1ILP), useSummary = false, TextILPSolver.curatorSRLViewName)
+      val result = solveTopAnswer(q, p, ilpSolver, aligner, Set(SRLV1ILP), useSummary = false, TextILPSolver.curatorSRLViewName)
+      ilpSolver.free()
+      result
     } -> "srlV1ILP_curator_srl"
     lazy val srlV1ILP_path_lstm = {
       val ilpSolver = new ScipSolver("textILP", ScipParams.Default)
-      solveTopAnswer(q, p, ilpSolver, aligner, Set(SRLV1ILP), useSummary = false, TextILPSolver.pathLSTMViewName)
+      val result = solveTopAnswer(q, p, ilpSolver, aligner, Set(SRLV1ILP), useSummary = false, TextILPSolver.pathLSTMViewName)
+      ilpSolver.free()
+      result
     } -> "srlV1ILP_path_lstm"
 
     val resultOpt = Constants.textILPModel match {
@@ -540,7 +566,9 @@ class TextILPSolver(annotationUtils: AnnotationUtils,
       case CauseRule => CauseResultRules(q, p)
       case x =>
         val ilpSolver = new ScipSolver("textILP", ScipParams.Default)
-        solveTopAnswer(q, p, ilpSolver, aligner, Set(x), useSummary = true, srlViewName)
+        val result = solveTopAnswer(q, p, ilpSolver, aligner, Set(x), useSummary = true, srlViewName)
+        ilpSolver.free()
+        result
     }
   }
 
@@ -561,7 +589,9 @@ class TextILPSolver(annotationUtils: AnnotationUtils,
           case CauseRule => CauseResultRules(q, p)
           case x =>
             val ilpSolver = new ScipSolver("textILP", ScipParams.Default)
-            solveTopAnswer(q, p, ilpSolver, aligner, Set(x), useSummary = true, srlViewName)
+            val result = solveTopAnswer(q, p, ilpSolver, aligner, Set(x), useSummary = true, srlViewName)
+            ilpSolver.free()
+            result
         }
       }
     }
@@ -3233,7 +3263,9 @@ class TextILPSolver(annotationUtils: AnnotationUtils,
           }
         }
 
-        solveExcludingAnswerOptions(Set.empty, Seq.empty)
+        val result = solveExcludingAnswerOptions(Set.empty, Seq.empty)
+        ilpSolver.free()
+        result
     }
   }
 


### PR DESCRIPTION
There was a native memory leak from `IlpSolver` as the constructed ILP object wasn't properly freed up in the C++ land without an explicit call to `ilpsolver.free()`.  That's fixed now and the native memory footprint seems stable (does not grow with the number of questions, for 1000+ questions).  In addition:

* `LD_LIBRARY_PATH` is now set as part of `runVis.sh`.
* Switched to a non-SNAPSHOT version of the entailment library.